### PR TITLE
copy over Media folder for examples to build directory

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -57,3 +57,6 @@ thor_example(Shapes)
 thor_example(Time)
 thor_example(Triangulation)
 thor_example(UserEvents)
+
+#Copy over Media folder to build directory (images, fonts, and such)
+file(COPY Media DESTINATION ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
The examples build folder is missing the Media folder that contains the fonts and images and other files for the examples.  This updates the CMake build system to copy this folder.
