### PR TITLE
Eliminate CMAKE_SOURCE_DIR from CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,8 +44,8 @@ project(thor)
 
 # Global preprocessor and include options
 add_definitions(-DTHOR_EXPORTS)
-include_directories(${CMAKE_SOURCE_DIR}/include)
-include_directories(${CMAKE_SOURCE_DIR}/extlibs/aurora/include)
+include_directories(include)
+include_directories(extlibs/aurora/include)
 
 # Predefined configuration options
 set(THOR_SHARED_LIBS TRUE CACHE BOOL "Build shared libraries (use shared SFML librares)")
@@ -94,7 +94,7 @@ endif()
 
 
 # Add directory containing FindSFML.cmake to module path
-set (CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules/;${CMAKE_MODULE_PATH}")
+set (CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/;${CMAKE_MODULE_PATH}")
 
 
 # Find SFML


### PR DESCRIPTION
This PR contains a commit that eliminates CMAKE_SOURCE_DIR in include_directories() because include_directories is evaluated relative to the current source directory (i.e. CMAKE_CURRENT_SOURCE_DIR) and replaces the remaining CMAKE_SOURCE_DIR instance with CMAKE_CURRENT_SOURCE_DIR.

Rationale for the change: When Thor is included in another CMake project via add_directories, CMAKE_SOURCE_DIR is the top-level project, not Thor.  This can lead to incorrect path construction.  In the above case, usage of CMAKE_CURRENT_SOURCE_DIR yields the correct paths.

Tested with CMake 2.8.11.2.
