### PR TITLE
Change CMAKE_SOURCE_DIR to PROJECT_SOURCE_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,8 +44,8 @@ project(thor)
 
 # Global preprocessor and include options
 add_definitions(-DTHOR_EXPORTS)
-include_directories(${CMAKE_SOURCE_DIR}/include)
-include_directories(${CMAKE_SOURCE_DIR}/extlibs/aurora/include)
+include_directories(${PROJECT_SOURCE_DIR}/include)
+include_directories(${PROJECT_SOURCE_DIR}/extlibs/aurora/include)
 
 # Predefined configuration options
 set(THOR_SHARED_LIBS TRUE CACHE BOOL "Build shared libraries (use shared SFML librares)")


### PR DESCRIPTION
This change enables adding Thor as a subproject of another CMake project. This is extremely useful when adding Thor as a git submodule of another projects. It allows the automatic compilation of Thor as part of the recursive project structure without messing it up for people who want to only build it the normal way.

This especially makes sense for people who want to keep tracking Thor from git and directly use it in their projects as well without installing Thor into the system.
