### PR TITLE
[buildfiles] Fixed Thor not building with clang on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ endif()
 if(CMAKE_COMPILER_IS_GNUCXX)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -stdlib=libc++")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
 	add_definitions(-DTHOR_USE_STD_RANDOMENGINE) # Workaround for libc++ bug
 endif()
 


### PR DESCRIPTION
On my system (ArchLinux with clang-svn 3.5-trunk), Thor would not build due to not being able to find certain headers.

This PR fixes that by not making libc++ a requirement on all systems, thus allowing the user to pick which stdlib to use.
