### PR TITLE
Correct sf::Time division problem.

### DIFF
--- a/include/Thor/Particles/Particle.hpp
+++ b/include/Thor/Particles/Particle.hpp
@@ -97,11 +97,11 @@ sf::Time THOR_API			getTotalLifetime(const Particle& particle);
 sf::Time THOR_API			getRemainingLifetime(const Particle& particle);
 
 /// @relates Particle
-/// @brief Returns <b>elapsed lifetime / total lifetime</b>.
+/// @brief Returns <b>elapsed lifetime / total lifetime</b> in seconds.
 float THOR_API				getElapsedRatio(const Particle& particle);
 
 /// @relates Particle
-/// @brief Returns <b>remaining lifetime / total lifetime</b>.
+/// @brief Returns <b>remaining lifetime / total lifetime</b> in seconds.
 float THOR_API				getRemainingRatio(const Particle& particle);
 
 /// @}

--- a/src/Particle.cpp
+++ b/src/Particle.cpp
@@ -59,12 +59,12 @@ sf::Time getRemainingLifetime(const Particle& particle)
 
 float getElapsedRatio(const Particle& particle)
 {
-	return getElapsedLifetime(particle) / getTotalLifetime(particle);
+	return getElapsedLifetime(particle).asSeconds() / getTotalLifetime(particle).asSeconds();
 }
 
 float getRemainingRatio(const Particle& particle)
 {
-	return getRemainingLifetime(particle) / getTotalLifetime(particle);
+	return getRemainingLifetime(particle).asSeconds() / getTotalLifetime(particle).asSeconds();
 }
 
 } // namespace thor


### PR DESCRIPTION
There's no operator/ definition for sf::Time so have the functions divide time in seconds.
