### PR TITLE
Add the ability to manually invoke removal of the particle.

### DIFF
--- a/include/Thor/Particles/Particle.hpp
+++ b/include/Thor/Particles/Particle.hpp
@@ -52,7 +52,7 @@ class THOR_API Particle
 	// Public member functions
 	public:
 		/// @brief Constructor
-		/// @param totalLifetime How long the particle totally exists.
+		/// @param totalLifetime How long the particle totally exists. Give sf::Time::Zero to manually invoke removal of the particle by manipulating its isDead variable
 		explicit					Particle(sf::Time totalLifetime);
 
 
@@ -66,6 +66,7 @@ class THOR_API Particle
 		sf::Vector2f				scale;				///< Scale, where (1,1) represents the original size.
 		sf::Color					color;				///< %Particle color.
 		unsigned int				textureIndex;		///< Index of the used texture rect, returned by ParticleSystem::addTextureRect()
+		bool						isDead; //This is set to true If the particle is wanted to be removed
 
 
 	// ---------------------------------------------------------------------------------------------------------------------------

--- a/src/Particle.cpp
+++ b/src/Particle.cpp
@@ -37,6 +37,7 @@ Particle::Particle(sf::Time totalLifetime)
 , scale(1.f, 1.f)
 , color(255, 255, 255)
 , textureIndex(0)
+, isDead(false)
 , passedLifetime(sf::Time::Zero)
 , totalLifetime(totalLifetime)
 {

--- a/src/ParticleSystem.cpp
+++ b/src/ParticleSystem.cpp
@@ -164,7 +164,7 @@ void ParticleSystem::update(sf::Time dt)
 		updateParticle(*reader, dt);
 
 		// If current particle is not dead
-		if (reader->passedLifetime < reader->totalLifetime)
+		if ((reader->totalLifetime > sf::seconds(0) && reader->passedLifetime < reader->totalLifetime) || !reader->isDead)
 		{
 			// Only apply affectors to living particles
 			AURORA_FOREACH(auto& affectorPair, mAffectors)


### PR DESCRIPTION
This way, one can remove the particles based on their positions, colors etc... This is useful for situations when a particle must exist not depending of the time but its position.
I think this is a useful feature, but the construction might be a problem, it might be a better idea to add a constructor with no parameters.
