### PR TITLE
Silence warnings [-Wlogical-op-parentheses]

### DIFF
--- a/extlibs/aurora/include/Aurora/Tools/Optional.hpp
+++ b/extlibs/aurora/include/Aurora/Tools/Optional.hpp
@@ -334,8 +334,8 @@ Optional<T> makeOptional(Args&&... args)
 template <typename T>
 bool operator== (const Optional<T>& lhs, const Optional<T>& rhs)
 {
-	return !lhs && !rhs
-		|| lhs && rhs && *lhs == *rhs;
+	return (!lhs && !rhs)
+		|| (lhs && rhs && *lhs == *rhs);
 }
 
 /// @relates Optional


### PR DESCRIPTION
Optional.hpp:337:14: warning: '&&' within '||' [-Wlogical-op-parentheses]
        return !lhs && !rhs
ptional.hpp:338:17: warning: '&&' within '||' [-Wlogical-op-parentheses]
                || lhs && rhs && *lhs == *rhs;