### PR TITLE
Fix compiler error on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,12 +83,12 @@ endif()
 
 
 # Compiler-specific flags and definitions
-if(CMAKE_COMPILER_IS_GNUCXX)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
-elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+set(CMAKE_CXX_STANDARD 11)
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 	set(THOR_CLANG_STDLIB "" CACHE STRING "Chose standard library (libstdc++ or libc++) or leave empty for default")
 
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -Wno-switch -Wno-logical-op-parentheses")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-switch -Wno-logical-op-parentheses")
 	if(NOT THOR_CLANG_STDLIB STREQUAL "")
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=${THOR_CLANG_STDLIB}")
 	endif()

--- a/src/Random.cpp
+++ b/src/Random.cpp
@@ -76,13 +76,13 @@ namespace
 			}
 
 			// Return minimal value (compliant to Std.Random)
-			static sf::Uint32 min()
+			static constexpr sf::Uint32 min()
 			{
 				return 0;
 			}
 
 			// Return maximal value (compliant to Std.Random)
-			static sf::Uint32 max()
+			static constexpr sf::Uint32 max()
 			{
 				return 0xffffffff;
 			}


### PR DESCRIPTION
The  `-std=c++0x` flag didn't work on macOS (anymore?), plus I don't think it's worth trying to support compilers which semi-support C++11.
Additionally, the custom random generator engine doesn't comply with the actual class definition, so I added the missing `constexpr`.
My personal suggestion would be to dump all the semi-C++11 bits and go full on C++11 (or C++17 if you want).

In the meantime this fix, made [my build work](https://github.com/eXpl0it3r/SmallGameFramework/runs/3036631961) also on macOS (via GitHub Actions).